### PR TITLE
Add version back into compile notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Add to your module's build.gradle:
 ```Groovy
 dependencies {
     //...
-    compile 'com.yalantis:starwarstiles:x.y.z'
+    compile 'com.yalantis:starwarstiles:0.1.1'
 }
 ```
 


### PR DESCRIPTION
Just updating the compile line. It read:
'com.yalantis:starwarstiles:x.y.z'
Updated it to the current version:
'com.yalantis:starwarstiles:0.1.1'
